### PR TITLE
Update for Rails 3.2

### DIFF
--- a/jquery-tablesorter.gemspec
+++ b/jquery-tablesorter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 3.1.1"
+  s.add_dependency "railties", "~> 3.1"
   s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
You depend explicitly on Rails 3.1.x. Instead, depend on Railties 3.x.
